### PR TITLE
chore: Add failing unit tests showing problem with asyncFn and vi.mock(<some-module>)

### DIFF
--- a/.github/workflows/jest-integration-testing.yml
+++ b/.github/workflows/jest-integration-testing.yml
@@ -37,5 +37,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+        working-directory: ./packages/jest
         env:
           CI: true

--- a/.github/workflows/jest-integration-testing.yml
+++ b/.github/workflows/jest-integration-testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         jest-version: [27.x, 28.x, 29.x, 30.x]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sinon-integration-testing.yml
+++ b/.github/workflows/sinon-integration-testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         sinon-version: [9.x, 14.x, 17.x, 19.x, 21.x]
 
     steps:

--- a/.github/workflows/sinon-integration-testing.yml
+++ b/.github/workflows/sinon-integration-testing.yml
@@ -37,5 +37,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+        working-directory: ./packages/sinon
         env:
           CI: true

--- a/.github/workflows/vitest-integration-testing.yml
+++ b/.github/workflows/vitest-integration-testing.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         node-version: [20.x, 22.x, 24.x]
-        vitest-version: [2.x, 3.x, 4.x]
+        vitest-version: [4.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vitest-integration-testing.yml
+++ b/.github/workflows/vitest-integration-testing.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         vitest-version: [1.x, 2.x, 3.x]
 
     steps:

--- a/.github/workflows/vitest-integration-testing.yml
+++ b/.github/workflows/vitest-integration-testing.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         node-version: [20.x, 22.x, 24.x]
-        vitest-version: [1.x, 2.x, 3.x]
+        vitest-version: [2.x, 3.x, 4.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,5 +37,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+        working-directory: ./packages/vitest
         env:
           CI: true

--- a/packages/core/src/asyncFnFor.js
+++ b/packages/core/src/asyncFnFor.js
@@ -11,86 +11,97 @@ import matches from 'lodash/fp/matches';
 const pipeline = (data, ...functions) => flow(...functions)(data);
 const mutatingRemove = remove.convert({ immutable: false });
 
-export default ({ mockFunctionFactory }) => (...args) => {
-  if (args.length > 0) {
-    throw new Error(mockImplementationUsageErrorMessage);
-  }
+const callStack = Symbol('callStack');
 
-  const callStack = [];
-
-  const asyncFn = mockFunctionFactory((...callArguments) => {
-    let resolve;
-    let reject;
-
-    const callPromise = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-
-    callStack.push({
-      callArguments,
-
-      resolve: (resolvedValue) => {
-        resolve(resolvedValue);
-        return flushMicroAndMacroTasks();
-      },
-
-      reject: (rejectedValue) => {
-        reject(rejectedValue);
-        return flushMicroAndMacroTasks();
-      },
-    });
-
-    return callPromise;
-  });
-
-  asyncFn.reject = (rejectedValue) => {
-    const oldestUnresolvedCall = callStack.shift();
-
-    if (!oldestUnresolvedCall) {
-      throw new Error(
-        'Tried to reject an asyncFn call that has not been made yet.',
-      );
+export default (options) =>
+  (...args) => {
+    const { mockFunctionFactory, callstackLocation = (mockFn) => mockFn } =
+      options;
+    if (args.length > 0) {
+      throw new Error(mockImplementationUsageErrorMessage);
     }
 
-    return oldestUnresolvedCall.reject(rejectedValue);
-  };
+    const impl = (...callArguments) => {
+      let resolve;
+      let reject;
 
-  asyncFn.resolve = (resolvedValue) => {
-    const oldestUnresolvedCall = callStack.shift();
+      const callPromise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
 
-    if (!oldestUnresolvedCall) {
-      throw new Error(
-        'Tried to resolve an asyncFn call that has not been made yet.',
+      getCalls().push({
+        callArguments,
+
+        resolve: (resolvedValue) => {
+          resolve(resolvedValue);
+          return flushMicroAndMacroTasks();
+        },
+
+        reject: (rejectedValue) => {
+          reject(rejectedValue);
+          return flushMicroAndMacroTasks();
+        },
+      });
+
+      return callPromise;
+    };
+    const asyncFn = mockFunctionFactory(impl);
+    const getCalls = () =>
+      callstackLocation(asyncFn)[callStack] ??
+      Object.defineProperty(callstackLocation(asyncFn), callStack, {
+        configurable: false,
+        enumerable: false,
+        value: [],
+      })[callStack];
+
+    asyncFn.reject = (rejectedValue) => {
+      const oldestUnresolvedCall = getCalls().shift();
+
+      if (!oldestUnresolvedCall) {
+        throw new Error(
+          'Tried to reject an asyncFn call that has not been made yet.',
+        );
+      }
+
+      return oldestUnresolvedCall.reject(rejectedValue);
+    };
+
+    asyncFn.resolve = (resolvedValue) => {
+      const oldestUnresolvedCall = getCalls().shift();
+
+      if (!oldestUnresolvedCall) {
+        throw new Error(
+          'Tried to resolve an asyncFn call that has not been made yet.',
+        );
+      }
+
+      return oldestUnresolvedCall.resolve(resolvedValue);
+    };
+
+    asyncFn.resolveSpecific = (predicateThing, resolvedValue) => {
+      const predicate = isFunction(predicateThing)
+        ? predicateThing
+        : matches(predicateThing);
+
+      return pipeline(
+        getCalls(),
+
+        mutatingRemove(flow(get('callArguments'), predicate)),
+
+        tap((callsToBeResolved) => {
+          if (callsToBeResolved.length === 0) {
+            throw new Error(
+              'Tried to resolve specific asyncFn call that could not be found. Calls:\n' +
+                JSON.stringify(getCalls().map(get('callArguments')), null, 2),
+            );
+          }
+        }),
+
+        map((callToBeResolved) => callToBeResolved.resolve(resolvedValue)),
+        Promise.all.bind(Promise),
       );
-    }
+    };
 
-    return oldestUnresolvedCall.resolve(resolvedValue);
+    return asyncFn;
   };
-
-  asyncFn.resolveSpecific = (predicateThing, resolvedValue) => {
-    const predicate = isFunction(predicateThing)
-      ? predicateThing
-      : matches(predicateThing);
-
-    return pipeline(
-      callStack,
-
-      mutatingRemove(flow(get('callArguments'), predicate)),
-
-      tap((callsToBeResolved) => {
-        if (callsToBeResolved.length === 0) {
-          throw new Error(
-            'Tried to resolve specific asyncFn call that could not be found. Calls:\n' +
-              JSON.stringify(callStack.map(get('callArguments')), null, 2),
-          );
-        }
-      }),
-
-      map((callToBeResolved) => callToBeResolved.resolve(resolvedValue)),
-      Promise.all.bind(Promise),
-    );
-  };
-
-  return asyncFn;
-};

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -29,7 +29,7 @@
     "@async-fn/core": "^1.7.0"
   },
   "peerDependencies": {
-    "sinon": "^9.0.2"
+    "sinon": ">= 9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -9,6 +9,17 @@ This simplifies async unit testing by allowing tests that read chronologically, 
 ```
 $ npm install --save-dev @async-fn/vitest
 ```
+
+In your `vitest.config.js` ensure that you have the following configuration. This is required when using `vi.mock(<some-module>)`.
+
+```js
+export default defineConfig({
+  test: {
+    clearMocks: true,
+  }
+})
+```
+
 ## Examples
 
 ### Late resolve for calls to a mock to make tests read like a story

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -39,7 +39,7 @@
     "@async-fn/core": "^1.7.0"
   },
   "peerDependencies": {
-    "vitest": ">= 1.0.0"
+    "vitest": ">= 2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -39,7 +39,7 @@
     "@async-fn/core": "^1.7.0"
   },
   "peerDependencies": {
-    "vitest": ">= 2.0.0"
+    "vitest": ">= 4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest/src/asyncFnForVitest.js
+++ b/packages/vitest/src/asyncFnForVitest.js
@@ -8,6 +8,7 @@ import { vi } from 'vitest';
 export default (...args) => {
   const mockFunctionInstance = asyncFnFor({
     mockFunctionFactory: vi.fn,
+    callstackLocation: (mockFn) => mockFn.mock.calls,
   })(...args);
 
   mockFunctionInstance.mockImplementation = throwMockImplementationUsageError;

--- a/packages/vitest/src/tests/async-fn-for-vitest.test.js
+++ b/packages/vitest/src/tests/async-fn-for-vitest.test.js
@@ -1,0 +1,42 @@
+import './some-module.mock';
+import * as SomeModule from './some-module';
+
+const someAsyncFunctionMock = SomeModule.someAsyncFunction;
+
+describe('given some instance which calls a mocked function', () => {
+  let topLevelFn;
+
+  beforeEach(() => {
+    topLevelFn = vi.fn(async (...args) => someAsyncFunctionMock(...args));
+  });
+
+  describe('when called in a beforeEach within a vitest describe', () => {
+    let callPromise;
+
+    beforeEach(() => {
+      callPromise = topLevelFn('some-arg');
+    });
+
+    it('calls the mock function', () => {
+      expect(someAsyncFunctionMock).toHaveBeenCalledExactlyOnceWith('some-arg');
+    });
+
+    it('has not resolved yet', () => {
+      expect(topLevelFn).not.toHaveResolved();
+    });
+
+    describe('when the mock resolves', () => {
+      beforeEach(async () => {
+        await someAsyncFunctionMock.resolve('some-resolved-value');
+      });
+
+      it('resolves the vitest fn tracker', () => {
+        expect(topLevelFn).toHaveResolvedWith('some-resolved-value');
+      });
+
+      it('resolves the actual promise returned too', async () => {
+        expect(await callPromise).toBe('some-resolved-value');
+      });
+    });
+  });
+});

--- a/packages/vitest/src/tests/some-module.js
+++ b/packages/vitest/src/tests/some-module.js
@@ -1,0 +1,3 @@
+export const someAsyncFunction = async () => {};
+
+export const someOtherAsyncFunction = async () => {};

--- a/packages/vitest/src/tests/some-module.mock.js
+++ b/packages/vitest/src/tests/some-module.mock.js
@@ -1,0 +1,7 @@
+import { vi } from 'vitest';
+import asyncFnForVitest from '../asyncFnForVitest';
+
+vi.mock(import('./some-module'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  someAsyncFunction: asyncFnForVitest(),
+}));

--- a/packages/vitest/vitest.config.js
+++ b/packages/vitest/vitest.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    clearMocks: true,
   },
 });


### PR DESCRIPTION
These tests fail, they fail due to sharing of state between test runs (namely the `calls` array within `@async-fn/core`) which needs to be cleaned up between tests.